### PR TITLE
Make RawModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Makefile*
+.bloop/*
+.metals/*
+.idea/*
+*~
+logs_*
+*.swp
+*.json
+*.fir
+project/*
+target/*
+src/test/scala/project/*
+src/test/scala/target/*
+verilog/

--- a/src/main/scala/clockmux_glitchfree/clockmux_glitchfree.scala
+++ b/src/main/scala/clockmux_glitchfree/clockmux_glitchfree.scala
@@ -50,11 +50,12 @@ class ClockMuxResetSync(activeLow: Boolean = false) extends BlackBox with HasBla
 
 class clockmux_glitchfreeIO(n_clocks: Int) extends Bundle {
  val clock_in = Input(Vec(n_clocks, Clock()))
+ val areset = Input(AsyncReset())
  val sel = Input(UInt(log2Ceil(n_clocks).W))
  val clock_out = Output(Clock())
 }
 
-class clockmux_glitchfree(n_clocks: Int) extends Module {
+class clockmux_glitchfree(n_clocks: Int) extends RawModule {
   require(n_clocks > 0, "Number of clocks cannot be zero")
   val io = IO(new clockmux_glitchfreeIO(n_clocks))
 
@@ -72,7 +73,7 @@ class clockmux_glitchfree(n_clocks: Int) extends Module {
   // Synchronize reset to all clock domains
   val reset_syncs = for (i <- 0 until n_clocks) yield {
     val reset_sync = Module(new ClockMuxResetSync(false))
-    reset_sync.io.areset_in := reset.asAsyncReset
+    reset_sync.io.areset_in := io.areset
     reset_sync.io.clock     := io.clock_in(i)
     reset_sync
   }
@@ -80,7 +81,7 @@ class clockmux_glitchfree(n_clocks: Int) extends Module {
   // Synchronize reset to inverted clock domain
   val reset_n_syncs = for (i <- 0 until n_clocks) yield {
     val reset_sync = Module(new ClockMuxResetSync(false))
-    reset_sync.io.areset_in := reset.asAsyncReset
+    reset_sync.io.areset_in := io.areset
     reset_sync.io.clock     := inverted_clocks(i)
     reset_sync
   }

--- a/src/main/scala/clockmux_glitchfree/clockmux_glitchfree.scala
+++ b/src/main/scala/clockmux_glitchfree/clockmux_glitchfree.scala
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Generalization of a 2-to-1 clock multiplexer shown in 
-// Intel Quartus Prime Pro Edition User Guide: Design Recommendations
-// https://www.intel.com/content/www/us/en/docs/programmable/683082/22-1/clock-multiplexing.html
-
 // Initially written by Tomi Valkonen (tomi.j.valkonen@aalto.fi), 2025-02-06
 package clockmux_glitchfree
 
@@ -15,7 +11,7 @@ import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
 class ClockMuxResetSync(activeLow: Boolean = false) extends BlackBox with HasBlackBoxInline {
   val io = IO(new Bundle {
     val clock        = Input(Clock())        // system clock
-    val areset_in    = Input(AsyncReset())   // async reset from external world with configurable polarity
+    val areset_in    = Input(AsyncReset())   // async reset from external world
     val areset_sync  = Output(AsyncReset())  // active high async reset with synchronized deassertion
   })
   val polarity = if (activeLow) "negedge" else "posedge"
@@ -55,6 +51,15 @@ class clockmux_glitchfreeIO(n_clocks: Int) extends Bundle {
  val clock_out = Output(Clock())
 }
 
+/**
+  *
+  * Generalization of a 2-to-1 clock multiplexer shown in 
+  * Intel Quartus Prime Pro Edition User Guide: Design Recommendations
+  * https://www.intel.com/content/www/us/en/docs/programmable/683082/22-1/clock-multiplexing.html
+  * 
+  *
+  * @param n_clocks
+  */
 class clockmux_glitchfree(n_clocks: Int) extends RawModule {
   require(n_clocks > 0, "Number of clocks cannot be zero")
   val io = IO(new clockmux_glitchfreeIO(n_clocks))


### PR DESCRIPTION
The main `clock` input is not used, so there is no point of having this be a Module.

Added reset to the input IO, and now it is clear that the reset is asynchronous (instead of the default clock and reset, where reset is assumed to be synchronous).

Also moved comment to class definition and added gitignore